### PR TITLE
Add support for Electrorad heaters

### DIFF
--- a/src/smartbox/resailer.py
+++ b/src/smartbox/resailer.py
@@ -55,6 +55,12 @@ class AvailableResailers:
             api_url="api-hjm",
             serial_id=10,
         ),
+        "api-evconfort": SmartboxResailer(
+            name="Electrorad",
+            web_url="https://app.controls-electrorad.co.uk/",
+            api_url="api-evconfort",
+            serial_id=12,
+        ),
         "api-haverland": SmartboxResailer(
             name="Haverland",
             web_url="https://i2control.haverland.com/",


### PR DESCRIPTION
Adds support for Electrorad branded heater units.

Serial ID was obtained from the web interface:

<img width="427" alt="Screenshot 2025-03-26 at 20 48 02" src="https://github.com/user-attachments/assets/df4c0f69-2aa9-424f-8e3b-33d22a396e6e" />
