### PR TITLE
Update UpdateManager to expose node version model

### DIFF
--- a/src/smartbox/models.py
+++ b/src/smartbox/models.py
@@ -83,6 +83,13 @@ class NodeSetup(RootModel[DefaultNodeSetup | PmoSetup]):
         """Get the root model directly."""
         return getattr(self.root, name)
 
+class NodeVersion(BaseModel):
+    """NodeVersion model."""
+    
+    hw_version: str
+    fw_version: str
+    uid: str
+    pid: str
 
 class DefaultNodeStatus(BaseModel):
     """Default Node Status."""
@@ -165,7 +172,6 @@ class Node(BaseModel):
     type: SmartboxNodeType
     installed: bool
     lost: bool | None = False
-
 
 class Nodes(BaseModel):
     """Nodes model."""

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -224,3 +224,61 @@ def test_update_manager_subscribe_to_device_connected(update_manager):
     update_data = {"path": "/connected", "body": {"connected": True}}
     update_manager._update_cb(update_data)
     callback.assert_called_once_with(update_data["body"]["connected"])
+
+
+
+def test_update_manager_subscribe_to_node_version(update_manager):
+    callback = MagicMock()
+    update_manager.subscribe_to_node_version(callback)
+    assert len(update_manager._dev_data_subscriptions) == 1
+    assert len(update_manager._update_subscriptions) == 1
+
+    # Test dev data callback
+    dev_data = {
+        "nodes": [
+            {
+                "type": "acm",
+                "addr": 2,
+                "version": {
+                    "pid": "081c",
+                    "fw_version": "1.6",
+                    "hw_version": "1.0",
+                    "uid": "test123",
+                },
+            }
+        ],
+    }
+    update_manager._dev_data_cb(dev_data)
+    callback.assert_called_once_with(
+        "acm",
+        2,
+        {
+            "pid": "081c",
+            "fw_version": "1.6",
+            "hw_version": "1.0",
+            "uid": "test123",
+        },
+    )
+
+    # Test update callback
+    callback.reset_mock()
+    update_data = {
+        "path": "/acm/2/version",
+        "body": {
+            "pid": "081c",
+            "fw_version": "1.7",
+            "hw_version": "1.0",
+            "uid": "test123",
+        },
+    }
+    update_manager._update_cb(update_data)
+    callback.assert_called_once_with(
+        "acm",
+        2,
+        {
+            "pid": "081c",
+            "fw_version": "1.7",
+            "hw_version": "1.0",
+            "uid": "test123",
+        },
+    )


### PR DESCRIPTION
Adds subscribe_to_node_version() method and NodeVersion model to expose device Product IDs via the UpdateManager. This allows clients to implement device-specific behavior based on the model code.

This chnage is needed by another PR (https://github.com/ajtudela/hass-smartbox/pull/45) to fix charge level sensors on specific storage heater models (the kind that I have at home). I'll be raising a seperate PR in the `hass-smartbox` repository consume this change and fix the charge level sensor for PID 1C heater models.